### PR TITLE
Fix hardcoded value and incorrect use of assertTrue

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -22,7 +22,7 @@ configurable int appId = ?;
 
 configurable string liveServerUrl = "https://api.hubapi.com/crm/v3/extensions/videoconferencing/settings";
 configurable string localServerUrl = "http://localhost:9090";
-configurable boolean isLiveServer = true;
+configurable boolean isLiveServer = false;
 
 final int:Signed32 appIdSigned32 = <int:Signed32>appId;
 final string serviceUrl = isLiveServer ? liveServerUrl : localServerUrl;
@@ -44,7 +44,7 @@ isolated function initClient() returns Client|error {
 @test:Config {}
 function testDeleteSettings() returns error? {
     http:Response response = check hubSpotVideoConferencing->/[appIdSigned32].delete();
-    test:assertTrue(response.statusCode == 204, "Error deleting settings");
+    test:assertEquals(response.statusCode, 204, "Error deleting settings");
 }
 
 // Test: Get settings when no settings are available (Negative)
@@ -136,6 +136,6 @@ function testPutCompeteSettings() returns error? {
 }
 function testDeleteSettingsAgain() returns error? {
     http:Response response = check hubSpotVideoConferencing->/[appIdSigned32].delete();
-    test:assertTrue(response.statusCode == 204, "Error deleting settings");
+    test:assertEquals(response.statusCode, 204, "Error deleting settings");
 }
 

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -25,6 +25,7 @@ configurable string localServerUrl = "http://localhost:9090";
 configurable boolean isLiveServer = false;
 
 final int:Signed32 appIdSigned32 = <int:Signed32>appId;
+final int:Signed32 incorrectAppId = 1234;
 final string serviceUrl = isLiveServer ? liveServerUrl : localServerUrl;
 final Client hubSpotVideoConferencing = check initClient();
 
@@ -76,7 +77,7 @@ function testPutIncorrectAppId() returns error? {
     ExternalSettings payload = {
         createMeetingUrl: "https://example.com/create-meeting"
     };
-    ExternalSettings|http:ClientRequestError|error settings = hubSpotVideoConferencing->/[1234].put(payload);
+    ExternalSettings|http:ClientRequestError|error settings = hubSpotVideoConferencing->/[incorrectAppId].put(payload);
     test:assertTrue(settings is http:ClientRequestError, "Error putting settings with incorrect appId");
 }
 
@@ -97,7 +98,7 @@ function testGetSettings() returns error? {
     dependsOn: [testPutSettings]
 }
 function testGetIncorrectAppId() returns error? {
-    ExternalSettings|http:ClientRequestError|error settings = hubSpotVideoConferencing->/[1234]();
+    ExternalSettings|http:ClientRequestError|error settings = hubSpotVideoConferencing->/[incorrectAppId]();
     test:assertTrue(settings is http:ClientRequestError, "Error getting settings");
 }
 
@@ -106,7 +107,7 @@ function testGetIncorrectAppId() returns error? {
     dependsOn: [testGetSettings]
 }
 function testDeleteIncorrectAppId() returns error? {
-    http:Response response = check hubSpotVideoConferencing->/[1234].delete();
+    http:Response response = check hubSpotVideoConferencing->/[incorrectAppId].delete();
     test:assertEquals(response.statusCode, 404, "Error deleting settings with incorrect appId");
 }
 


### PR DESCRIPTION
- Use final variable for `incorrectAppId` in ./ballerina/test.bal instead of hard-coding the value
- Use `assertEquals()` for checking status code of response instead of `assertTrue()`
